### PR TITLE
Remove outdated YouTube filters

### DIFF
--- a/mv.txt
+++ b/mv.txt
@@ -1,6 +1,6 @@
 [Adblock Plus 2.0]
 ! Title: 乘风 视频过滤规则
-! Version: 202307122
+! Version: 202310221
 ! Expires: 1 day
 ! Homepage: https://github.com/xinggsf/Adblock-Plus-Rule/issues
 
@@ -146,9 +146,6 @@ litix.io
 youtube.com##.masthead-ad-control, .ad-div, .pyv-afc-ads-container, #promotion-shelf
 *_ad_$media,domain=youtube.com,3p
 youtube.com##ytd-video-masthead-ad-advertiser-info-renderer, ytm-promoted-sparkles-web-renderer, ytd-promoted-sparkles-web-renderer
-youtube.com,youtube-nocookie.com##+js(json-prune, [].playerResponse.adPlacements [].playerResponse.playerAds playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds)
-youtube.com,youtube-nocookie.com##+js(set, ytInitialPlayerResponse.adPlacements, undefined)
-youtube.com,youtube-nocookie.com##+js(set, playerResponse.adPlacements, undefined)
 ||youtube.com/pagead/
 ||youtube.com/ptracking?
 ||google.*/pagead/


### PR DESCRIPTION
One of these filters is causing anti-blocker on YouTube: https://github.com/uBlockOrigin/uAssets/issues/19976#issuecomment-1774090029

Additionally, YouTube's antiblocker has changed since July, so I doubt the other two work.
Due to the sophistication of YouTube's anti-blocker, I have chosen not to try to replace these filters with working ones.
Thank you